### PR TITLE
Fix typos and error handling

### DIFF
--- a/chi660_macro_0V1.py
+++ b/chi660_macro_0V1.py
@@ -117,7 +117,7 @@ class CHI660e(object):
 	def run_cv(self, file, filename:str='untitled', tsave=True, autosens=True, add_note=False):
 		try:
 			self.cv_ei
-		except NameError:
+		except AttributeError:
 			print("Initialize the variable first. use 'init_cv_tech' function")
 		else:
 			if add_note:
@@ -134,7 +134,7 @@ class CHI660e(object):
 			print("si:"+str(self.cv_si),file=file)
 			print("qt:"+str(self.cv_qt),file=file)
 			if autosens:
-				print("sutosens",file=file)
+				print("autosens",file=file)
 				pass
 			print("run",file=file)
 			print("save:"+filename,file=file)

--- a/chi660_macro_0V2.py
+++ b/chi660_macro_0V2.py
@@ -56,33 +56,33 @@ class CHI660e(object):
 		pass
 	""" Similarly Hereinafter: Generate the contral code and some other define """
 	def run_lsv(self, file, filename:str='untitled', tsave=True, autosens=True, add_note=False):
-		try:
-			self.lsv_si
-		except AttributeError:
-			print("Initialize the variable first. use 'init_lsv_tech' function")
-			sys.exit()
-		else:
-			if add_note:
-				print("# LSV from "+str(self.lsv_ei)+"V to "+str(self.lsv_ef)+"V with "+ \
-					str(self.lsv_v*1000)+"mV/s", file=file)
-				pass
-			print("tech:lsv",file=file)
-			print("ei:"+str(self.lsv_ei),file=file)
-			print("ef:"+str(self.lsv_ef),file=file)
-			print("v:"+str(self.lsv_v),file=file)
-			print("si:"+str(self.lsv_si),file=file)
-			print("qt:"+str(self.lsv_qt),file=file)
-			print("sens:"+str(self.lsv_sens),file=file)
-			if autosens:
-				print("tsave:IT-"+str(loop),file=file)
-				pass
-			print("run",file=file)
-			print("save:IT-"+str(loop),file=file)
-			if tsave:
-				print("tsave:IT-"+str(loop),file=file)
-				pass
-			print(" ",file=file)
-		pass
+                try:
+                        self.lsv_si
+                except AttributeError:
+                        print("Initialize the variable first. use 'init_lsv_tech' function")
+                        sys.exit()
+                else:
+                        if add_note:
+                                print("# LSV from "+str(self.lsv_ei)+"V to "+str(self.lsv_ef)+"V with "+ \
+                                        str(self.lsv_v*1000)+"mV/s", file=file)
+                                pass
+                        print("tech:lsv",file=file)
+                        print("ei:"+str(self.lsv_ei),file=file)
+                        print("ef:"+str(self.lsv_ef),file=file)
+                        print("v:"+str(self.lsv_v),file=file)
+                        print("si:"+str(self.lsv_si),file=file)
+                        print("qt:"+str(self.lsv_qt),file=file)
+                        print("sens:"+str(self.lsv_sens),file=file)
+                        if autosens:
+                                print("autosens",file=file)
+                                pass
+                        print("run",file=file)
+                        print("save:"+filename,file=file)
+                        if tsave:
+                                print("tsave:"+filename,file=file)
+                                pass
+                        print(" ",file=file)
+                pass
 
 	def init_cv_tech(self, ei=0.0, eh=-0.1, el=-0.1, pn:str="p", v=0.01, cl:int=32, si=0.001, qt=2.0, sens=1e-3):
 		if -10.0<=ei<=10.0:
@@ -117,7 +117,7 @@ class CHI660e(object):
 	def run_cv(self, file, filename:str='untitled', tsave=True, autosens=True, add_note=False):
 		try:
 			self.cv_ei
-		except NameError:
+		except AttributeError:
 			print("Initialize the variable first. use 'init_cv_tech' function")
 		else:
 			if add_note:
@@ -135,7 +135,7 @@ class CHI660e(object):
 			print("qt:"+str(self.cv_qt),file=file)
 			print("sens:"+str(self.cv_sens),file=file)
 			if autosens:
-				print("sutosens",file=file)
+				print("autosens",file=file)
 				pass
 			print("run",file=file)
 			print("save:"+filename,file=file)
@@ -172,7 +172,7 @@ class CHI660e(object):
 	def run_scv(self, file, filename:str='untitled', tsave=True, autosens=True, add_note=False):
 		try:
 			self.scv_ei
-		except NameError:
+		except AttributeError:
 			print("Initialize the variable first. use 'init_scv_tech' function")
 		else:
 			if add_note:
@@ -188,7 +188,7 @@ class CHI660e(object):
 			print("sens:"+str(self.scv_sens),file=file)
 			print("qt:"+str(self.scv_qt),file=file)
 			if autosens:
-				print("sutosens",file=file)
+				print("autosens",file=file)
 				pass
 			print("run",file=file)
 			print("save:"+filename,file=file)
@@ -219,7 +219,7 @@ class CHI660e(object):
 	def run_it(self, file, filename:str='untitled', tsave=True, autosens=True, add_note=False):
 		try:
 			self.it_ei
-		except NameError:
+		except AttributeError:
 			print("Initialize the variable first. use 'init_it_tech' function")
 		else:
 			if add_note:
@@ -233,7 +233,7 @@ class CHI660e(object):
 			print("qt:"+str(self.it_qt),file=file)
 			print("sens:"+str(self.it_sens),file=file)
 			if autosens:
-				print("sutosens",file=file)
+				print("autosens",file=file)
 				pass
 			print("run",file=file)
 			print("save:"+filename,file=file)
@@ -261,11 +261,11 @@ class CHI660e(object):
 			pass
 		pass
 
-	def run_be(self, file, filename:str='untbeled', tsave=True, autosens=True, add_note=False):
+	def run_be(self, file, filename:str='untitled', tsave=True, autosens=True, add_note=False):
 		try:
 			self.be_ei
-		except NameError:
-			print("Inbeialize the variable first. use 'inbe_be_tech' function")
+		except AttributeError:
+			print("Initialize the variable first. use 'init_be_tech' function")
 		else:
 			if add_note:
 				print("# be at "+str(self.be_ei)+"V with "+str(self.be_si)+"s inter till "+ \
@@ -278,7 +278,7 @@ class CHI660e(object):
 			print("bepe:"+str(self.be_bepe),file=file)
 			print("bept:"+str(self.be_bept),file=file)
 			if autosens:
-				print("sutosens",file=file)
+				print("autosens",file=file)
 				pass
 			print("run",file=file)
 			print("save:"+filename,file=file)
@@ -309,11 +309,11 @@ class CHI660e(object):
 			pass
 		pass
 
-	def run_imp(self, file, filename:str='untbeled', tsave=True, autosens=True, add_note=False):
+	def run_imp(self, file, filename:str='untitled', tsave=True, autosens=True, add_note=False):
 		try:
 			self.imp_ei
-		except NameError:
-			print("Inbeialize the variable first. use 'inimp_imp_tech' function")
+		except AttributeError:
+			print("Initialize the variable first. use 'init_imp_tech' function")
 		else:
 			if add_note:
 				print("# imp at "+str(self.imp_ei)+"V from "+str(self.imp_fl)+"Hz to "+ \
@@ -327,7 +327,7 @@ class CHI660e(object):
 			print("qt:"+str(self.imp_qt),file=file)
 			print("sens:"+str(self.imp_sens),file=file)
 			if autosens:
-				print("sutosens",file=file)
+				print("autosens",file=file)
 				pass
 			print("run",file=file)
 			print("save:"+filename,file=file)


### PR DESCRIPTION
## Summary
- improve error handling by checking for missing attributes
- fix typos of `autosens`
- fix incorrect messages and defaults

## Testing
- `python3 -m py_compile chi660_macro_0V2.py chi660_macro_0V1.py`
- `python3 chi660_macro_0V2.py > /tmp/out.txt && tail -n 5 /tmp/out.txt`

------
https://chatgpt.com/codex/tasks/task_e_685fb66591a4832eb9356e2837b89e1a